### PR TITLE
add warning for no injected Web3 library

### DIFF
--- a/client/assets-client.js
+++ b/client/assets-client.js
@@ -110,6 +110,10 @@ class AssetsClient extends AbstractClient {
 
     loadMetamask(){
         if (window.ethereum) {
+            if(typeof Web3 === "undefined" || !window?.Web3){
+                console.warn("NO web3 implementation injected, please inject your own Web3 implementation to use metamask");
+                return ;
+            }
             window.web3 = new Web3(ethereum);
             ethereum.enable()
                 .then(() => {

--- a/client/assets-client.js
+++ b/client/assets-client.js
@@ -111,7 +111,7 @@ class AssetsClient extends AbstractClient {
     loadMetamask(){
         if (window.ethereum) {
             if(typeof Web3 === "undefined" || !window?.Web3){
-                console.warn("NO web3 implementation injected, please inject your own Web3 implementation to use metamask");
+                console.warn("No web3 implementation injected, please inject your own Web3 implementation to use metamask");
                 return ;
             }
             window.web3 = new Web3(ethereum);


### PR DESCRIPTION
This will add a console warning when no web3 implementation is injected when `ethereum` is injected (aka metamask is installed) and prevent a script crash