### PR TITLE
Fix issues for getting bid suggestion

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -51,6 +51,7 @@ module.exports.PUBLISH_TRIPLES_NUMBER = 10;
 module.exports.PUBLISH_CHUNKS_NUMBER = 10;
 module.exports.PUBLISH_EPOCHS_NUM = 5;
 module.exports.PUBLISH_TOKEN_AMOUNT = 15;
+module.exports.DEFAULT_HASH_FUNCTION_ID = 1;
 
 module.exports.OPERATIONS = {
   publish: "publish",

--- a/constants.js
+++ b/constants.js
@@ -29,9 +29,13 @@ module.exports.BLOCKCHAINS = {
     rpc: "https://matic-mumbai.chainstacklabs.com",
     hubContract: "0xdaa16AC171CfE8Df6F79C06E7EEAb2249E2C9Ec8", // TODO: change to Asset Contract
   },
-  otp: {
+  "otp::testnet": {
     rpc: "https://lofar-testnet.origin-trail.network",
     hubContract: "0xEF9FeCb85d03d6e624C434dF8298692d13853033",
+  },
+  "otp::mainnet": {
+    rpc: "https://astrosat-parachain-rpc.origin-trail.network",
+    hubContract: "0x485Cbd3A5BCE1a9c1e5cD37AA02039D7C23fD0c3",
   },
 };
 

--- a/managers/asset-operations-manager.js
+++ b/managers/asset-operations-manager.js
@@ -34,12 +34,18 @@ class AssetOperationsManager {
 
     const assertion = await formatAssertion(content);
     const assertionId = calculateRoot(assertion);
+    const contentAssetStorageAddress = await this.blockchainService.getContractAddress(
+        blockchain.name,
+        "ContentAssetStorage",
+        blockchain.rpc
+    );
     const tokenAmountInWei =
       options.tokenAmount ??
       (await this.nodeApiService.getBidSuggestion(
         options.blockchain.name.startsWith("otp") ? "otp" : options.blockchain.name,
         options.epochsNum,
         assertionMetadata.getAssertionSizeInBytes(assertion),
+        contentAssetStorageAddress,
         options.hashFunctionId ?? DEFAULT_HASH_FUNCTION_ID,
         options
       ));
@@ -60,11 +66,7 @@ class AssetOperationsManager {
     const blockchain = this.blockchainService.getBlockchain(options)
     const UAL = Utilities.deriveUAL(
       blockchain.name,
-      await this.blockchainService.getContractAddress(
-        blockchain.name,
-        "ContentAssetStorage",
-        blockchain.rpc
-      ),
+      contentAssetStorageAddress,
       tokenId
     );
 

--- a/managers/asset-operations-manager.js
+++ b/managers/asset-operations-manager.js
@@ -37,13 +37,12 @@ class AssetOperationsManager {
     const tokenAmountInWei =
       options.tokenAmount ??
       (await this.nodeApiService.getBidSuggestion(
-        options.blockchain.name,
+        options.blockchain.name.startsWith("otp") ? "otp" : options.blockchain.name,
         options.epochsNum,
         assertionMetadata.getAssertionSizeInBytes(assertion),
         options.hashFunctionId ?? DEFAULT_HASH_FUNCTION_ID,
         options
       ));
-
     const tokenId = await this.blockchainService.createAsset(
       {
         assertionId,

--- a/managers/asset-operations-manager.js
+++ b/managers/asset-operations-manager.js
@@ -34,6 +34,7 @@ class AssetOperationsManager {
 
     const assertion = await formatAssertion(content);
     const assertionId = calculateRoot(assertion);
+    const blockchain = this.blockchainService.getBlockchain(options);
     const contentAssetStorageAddress = await this.blockchainService.getContractAddress(
         blockchain.name,
         "ContentAssetStorage",
@@ -42,10 +43,11 @@ class AssetOperationsManager {
     const tokenAmountInWei =
       options.tokenAmount ??
       (await this.nodeApiService.getBidSuggestion(
-        options.blockchain.name.startsWith("otp") ? "otp" : options.blockchain.name,
+        blockchain.name,
         options.epochsNum,
         assertionMetadata.getAssertionSizeInBytes(assertion),
         contentAssetStorageAddress,
+        assertionId,
         options.hashFunctionId ?? DEFAULT_HASH_FUNCTION_ID,
         options
       ));
@@ -63,7 +65,6 @@ class AssetOperationsManager {
       stepHooks
     );
 
-    const blockchain = this.blockchainService.getBlockchain(options)
     const UAL = Utilities.deriveUAL(
       blockchain.name,
       contentAssetStorageAddress,

--- a/managers/asset-operations-manager.js
+++ b/managers/asset-operations-manager.js
@@ -9,7 +9,7 @@ const jsonld = require("jsonld");
 const {
   OPERATIONS,
   PUBLISH_TYPES,
-  BLOCKCHAINS,
+  DEFAULT_HASH_FUNCTION_ID,
   OPERATIONS_STEP_STATUS,
   GET_OUTPUT_FORMATS,
 } = require("../constants.js");
@@ -34,12 +34,13 @@ class AssetOperationsManager {
 
     const assertion = await formatAssertion(content);
     const assertionId = calculateRoot(assertion);
-    const tokenAmount =
+    const tokenAmountInWei =
       options.tokenAmount ??
       (await this.nodeApiService.getBidSuggestion(
         options.blockchain.name,
         options.epochsNum,
         assertionMetadata.getAssertionSizeInBytes(assertion),
+        options.hashFunctionId ?? DEFAULT_HASH_FUNCTION_ID,
         options
       ));
 
@@ -50,9 +51,7 @@ class AssetOperationsManager {
         triplesNumber: assertionMetadata.getAssertionTriplesNumber(assertion),
         chunksNumber: assertionMetadata.getAssertionChunksNumber(assertion),
         epochsNum: options.epochsNum,
-        tokenAmount: this.blockchainService.convertToWei(
-          Math.ceil(parseFloat(tokenAmount))
-        ),
+        tokenAmount: tokenAmountInWei,
         scoreFunctionId: options.scoreFunctionId ?? 1,
       },
       options,
@@ -159,6 +158,7 @@ class AssetOperationsManager {
         options.blockchain.name,
         options.epochsNum,
         assertionMetadata.getAssertionSizeInBytes(assertion),
+        options.hashFunctionId ?? DEFAULT_HASH_FUNCTION_ID,
         options
       ));
 

--- a/managers/asset-operations-manager.js
+++ b/managers/asset-operations-manager.js
@@ -170,7 +170,7 @@ class AssetOperationsManager {
         triplesNumber: assertionMetadata.getAssertionTriplesNumber(assertion),
         chunksNumber: assertionMetadata.getAssertionChunksNumber(assertion),
         epochsNum: options.epochsNum,
-        tokenAmount: this.blockchainService.convertToWei(tokenAmount),
+        tokenAmount: tokenAmount,
         scoreFunctionId: options.scoreFunctionId ?? 1,
       },
       options

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dkg.js",
-  "version": "6.0.0-beta.3.4.3",
+  "version": "6.0.0-beta.3.4.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dkg.js",
-      "version": "6.0.0-beta.3.4.3",
+      "version": "6.0.0-beta.3.4.5",
       "license": "Apache-2.0",
       "dependencies": {
         "assertion-tools": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dkg.js",
-  "version": "6.0.0-beta.3.4.3",
+  "version": "6.0.0-beta.3.4.5",
   "description": "Javascript library for interaction with the OriginTrail Decentralized Knowledge Graph",
   "main": "index.js",
   "scripts": {

--- a/services/blockchain-service/blockchain-service-base.js
+++ b/services/blockchain-service/blockchain-service-base.js
@@ -76,7 +76,7 @@ class BlockchainServiceBase {
 
     let gasPrice;
 
-    if (blockchain.name === "otp") {
+    if (blockchain.name.startsWith("otp")) {
       gasPrice = await web3Instance.eth.getGasPrice();
     } else {
       gasPrice = Web3.utils.toWei("100", "Gwei");

--- a/services/blockchain-service/implementations/browser-blockchain-service.js
+++ b/services/blockchain-service/implementations/browser-blockchain-service.js
@@ -13,7 +13,9 @@ class BrowserBlockchainService extends BlockchainServiceBase {
 
   getBlockchain(options) {
     return {
-      name: options.blockchain.name,
+      name: options.blockchain.name.startsWith("otp")
+        ? "otp"
+        : options.blockchain.name,
       hubContract:
         options.blockchain.hubContract ??
         BLOCKCHAINS[options.blockchain.name].hubContract,

--- a/services/node-api-service/implementations/http-service.js
+++ b/services/node-api-service/implementations/http-service.js
@@ -21,13 +21,13 @@ class HttpService {
     });
   }
 
-  async getBidSuggestion(blockchain, epochsNumber, assertionSize, hashFunctionId, options) {
+  async getBidSuggestion(blockchain, epochsNumber, assertionSize, contentAssetStorageAddress, hashFunctionId, options) {
     const endpoint = options.endpoint ?? this.config.endpoint;
 
     return axios({
       method: "get",
       url: `${endpoint}:${this.config.port}/bid-suggestion`,
-      params: { blockchain, epochsNumber, assertionSize, hashFunctionId },
+      params: { blockchain, epochsNumber, assertionSize, contentAssetStorageAddress, hashFunctionId },
       headers: this.prepareRequestConfig(),
     })
       .then((response) => {

--- a/services/node-api-service/implementations/http-service.js
+++ b/services/node-api-service/implementations/http-service.js
@@ -21,13 +21,28 @@ class HttpService {
     });
   }
 
-  async getBidSuggestion(blockchain, epochsNumber, assertionSize, contentAssetStorageAddress, hashFunctionId, options) {
+  async getBidSuggestion(
+    blockchain,
+    epochsNumber,
+    assertionSize,
+    contentAssetStorageAddress,
+    firstAssertionId,
+    hashFunctionId,
+    options
+  ) {
     const endpoint = options.endpoint ?? this.config.endpoint;
 
     return axios({
       method: "get",
       url: `${endpoint}:${this.config.port}/bid-suggestion`,
-      params: { blockchain, epochsNumber, assertionSize, contentAssetStorageAddress, hashFunctionId },
+      params: {
+        blockchain,
+        epochsNumber,
+        assertionSize,
+        contentAssetStorageAddress,
+        firstAssertionId,
+        hashFunctionId,
+      },
       headers: this.prepareRequestConfig(),
     })
       .then((response) => {

--- a/services/node-api-service/implementations/http-service.js
+++ b/services/node-api-service/implementations/http-service.js
@@ -21,13 +21,13 @@ class HttpService {
     });
   }
 
-  async getBidSuggestion(blockchain, epochsNumber, assertionSize, options) {
+  async getBidSuggestion(blockchain, epochsNumber, assertionSize, hashFunctionId, options) {
     const endpoint = options.endpoint ?? this.config.endpoint;
-    
+
     return axios({
       method: "get",
       url: `${endpoint}:${this.config.port}/bid-suggestion`,
-      params: { blockchain, epochsNumber, assertionSize },
+      params: { blockchain, epochsNumber, assertionSize, hashFunctionId },
       headers: this.prepareRequestConfig(),
     })
       .then((response) => {

--- a/services/utilities.js
+++ b/services/utilities.js
@@ -8,7 +8,7 @@ module.exports = {
     return parseInt(hex.slice(2), 16);
   },
   deriveUAL(blockchain, contract, tokenId) {
-    return `did:dkg:${blockchain.toLowerCase()}/${contract.toLowerCase()}/${tokenId}`;
+    return `did:dkg:${blockchain.startsWith("otp") ? "otp" : blockchain.toLowerCase()}/${contract.toLowerCase()}/${tokenId}`;
   },
   resolveUAL(ual) {
     const segments = ual.split(":");


### PR DESCRIPTION
This PR:
- Converts token amount to Wei
- Adds parachain mainnet and testnet
- Adds hash function ID to get bid suggestion call
- Adds ContenAssetStorage contract address to get bid suggestion call

In blockchain object for parachain testnet should be `otp::testnet`, and for parachain mainnet `otp::mainnet`. Like this:
```js
const blockchain = {
  name: "otp::testnet",
  publicKey: PUBLIC_KEY,
  privateKey: PRIVATE_KEY,
};
```

Note: This PR is dependent on [OT-node PR 22777](https://github.com/OriginTrail/ot-node/pull/2277), once this PR is merged and on network, this version of client can be used.