### PR TITLE
Check file size fix

### DIFF
--- a/managers/asset-operations-manager.js
+++ b/managers/asset-operations-manager.js
@@ -169,6 +169,15 @@ class AssetOperationsManager {
             ],
         };
         const publicAssertion = await formatAssertion(publicGraph);
+        const publicAssertionSizeInBytes =
+            assertionMetadata.getAssertionSizeInBytes(publicAssertion);
+
+        this.validationService.validateAssertionSizeInBytes(
+            publicAssertionSizeInBytes +
+                (privateAssertion === undefined
+                    ? 0
+                    : assertionMetadata.getAssertionSizeInBytes(privateAssertion)),
+        );
         const publicAssertionId = calculateRoot(publicAssertion);
 
         const contentAssetStorageAddress = await this.blockchainService.getContractAddress(
@@ -184,7 +193,7 @@ class AssetOperationsManager {
                 authToken,
                 blockchain.name.startsWith('otp') ? 'otp' : blockchain.name,
                 epochsNum,
-                assertionMetadata.getAssertionSizeInBytes(publicAssertion),
+                publicAssertionSizeInBytes,
                 contentAssetStorageAddress,
                 publicAssertionId,
                 hashFunctionId,
@@ -193,7 +202,7 @@ class AssetOperationsManager {
         const tokenId = await this.blockchainService.createAsset(
             {
                 publicAssertionId,
-                assertionSize: assertionMetadata.getAssertionSizeInBytes(publicAssertion),
+                assertionSize: publicAssertionSizeInBytes,
                 triplesNumber: assertionMetadata.getAssertionTriplesNumber(publicAssertion),
                 chunksNumber: assertionMetadata.getAssertionChunksNumber(publicAssertion),
                 epochsNum,
@@ -576,6 +585,15 @@ class AssetOperationsManager {
             ],
         };
         const publicAssertion = await formatAssertion(publicGraph);
+        const publicAssertionSizeInBytes =
+            assertionMetadata.getAssertionSizeInBytes(publicAssertion);
+
+        this.validationService.validateAssertionSizeInBytes(
+            publicAssertionSizeInBytes +
+                (privateAssertion === undefined
+                    ? 0
+                    : assertionMetadata.getAssertionSizeInBytes(privateAssertion)),
+        );
         const publicAssertionId = calculateRoot(publicAssertion);
 
         const contentAssetStorageAddress = await this.blockchainService.getContractAddress(
@@ -595,7 +613,7 @@ class AssetOperationsManager {
                 port,
                 authToken,
                 publicAssertionId,
-                assertionMetadata.getAssertionSizeInBytes(publicAssertion),
+                publicAssertionSizeInBytes,
                 hashFunctionId,
             );
         }
@@ -603,7 +621,7 @@ class AssetOperationsManager {
         await this.blockchainService.updateAsset(
             tokenId,
             publicAssertionId,
-            assertionMetadata.getAssertionSizeInBytes(publicAssertion),
+            publicAssertionSizeInBytes,
             assertionMetadata.getAssertionTriplesNumber(publicAssertion),
             assertionMetadata.getAssertionChunksNumber(publicAssertion),
             tokenAmountInWei,

--- a/services/validation-service.js
+++ b/services/validation-service.js
@@ -260,7 +260,6 @@ class ValidationService {
     }
 
     validateAssertionSizeInBytes(assertionSizeInBytes) {
-        console.log(assertionSizeInBytes);
         if (assertionSizeInBytes > MAX_FILE_SIZE)
             throw Error(`File size limit is ${MAX_FILE_SIZE / (1024 * 1024)}MB.`);
     }

--- a/services/validation-service.js
+++ b/services/validation-service.js
@@ -257,8 +257,11 @@ class ValidationService {
         if (!content.public && !content.private) {
             throw Error('Public or private content must be defined');
         }
+    }
 
-        if (Buffer.byteLength(JSON.stringify(content), 'utf-8') > MAX_FILE_SIZE)
+    validateAssertionSizeInBytes(assertionSizeInBytes) {
+        console.log(assertionSizeInBytes);
+        if (assertionSizeInBytes > MAX_FILE_SIZE)
             throw Error(`File size limit is ${MAX_FILE_SIZE / (1024 * 1024)}MB.`);
     }
 


### PR DESCRIPTION
Instead of validating the size of the content, now validate the size of the assertion(s) - in case there's a private one we will validate sum of sizes of public and private assertion, as ot-node checks the size of the request which includes both.

Before merging we can discuss whether we want to change the size/how this is checked on ot-node