### PR TITLE
Changed logic for increasing gas price, while retrying tx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "dkg.js",
-    "version": "6.0.10",
+    "version": "6.0.11",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "dkg.js",
-            "version": "6.0.10",
+            "version": "6.0.11",
             "license": "Apache-2.0",
             "dependencies": {
                 "assertion-tools": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dkg.js",
-    "version": "6.0.10",
+    "version": "6.0.11",
     "description": "Javascript library for interaction with the OriginTrail Decentralized Knowledge Graph",
     "main": "index.js",
     "scripts": {

--- a/services/blockchain-service/blockchain-service-base.js
+++ b/services/blockchain-service/blockchain-service-base.js
@@ -73,7 +73,7 @@ class BlockchainServiceBase {
 
         const encodedABI = await contractInstance.methods[functionName](...args).encodeABI();
 
-        let gasPrice = BigInt(
+        let gasPrice = Number(
             blockchain.previousTxGasPrice ||
             blockchain.gasPrice ||
             await this.getNetworkGasPrice(blockchain)
@@ -81,7 +81,7 @@ class BlockchainServiceBase {
 
         if (blockchain.retryTx) {
             // Increase gas price by 20%
-            gasPrice = gasPrice * BigInt(120) / BigInt(100);
+            gasPrice *= 1.2;
         }
 
         return {

--- a/services/blockchain-service/blockchain-service-base.js
+++ b/services/blockchain-service/blockchain-service-base.js
@@ -49,6 +49,17 @@ class BlockchainServiceBase {
         return;
     }
 
+    async getNetworkGasPrice(blockchain) {
+        const web3Instance = await this.getWeb3Instance(blockchain);
+
+        try {
+            return await web3Instance.eth.getGasPrice();
+        } catch (error) {
+            console.error(`Failed to fetch the gas price from the network: ${error}. Using default value: 100 Gwei.`);
+            return Web3.utils.toWei('100', 'Gwei');
+        }
+    }
+
     async callContractFunction(contractName, functionName, args, blockchain) {
         const contractInstance = await this.getContractInstance(contractName, blockchain);
         return contractInstance.methods[functionName](...args).call();
@@ -56,29 +67,21 @@ class BlockchainServiceBase {
 
     async prepareTransaction(contractInstance, functionName, args, blockchain) {
         const publicKey = await this.getPublicKey(blockchain);
-        const web3Instance = await this.getWeb3Instance(blockchain);
         const gasLimit = await contractInstance.methods[functionName](...args).estimateGas({
             from: blockchain.publicKey,
         });
 
         const encodedABI = await contractInstance.methods[functionName](...args).encodeABI();
 
-        let gasPrice;
-        if (blockchain.gasPrice === undefined) {
-            gasPrice = await web3Instance.eth.getGasPrice();
-        }
+        let gasPrice = BigInt(
+            blockchain.previousTxGasPrice ||
+            blockchain.gasPrice ||
+            await this.getNetworkGasPrice(blockchain)
+        );
 
-        // Gas price increase for handling `Transaction not mined` error
-        if (blockchain.retryTx && gasPrice <= blockchain.gasPrice) {
-            gasPrice = Number(blockchain.gasPrice) + 1;
-        } else if (blockchain.gasPrice) {
-            // Gas price provided by developers
-            gasPrice = blockchain.gasPrice;
-        }
-
-        // Fallback
-        if (!gasPrice) {
-            gasPrice = Web3.utils.toWei('100', 'Gwei');
+        if (blockchain.retryTx) {
+            // Increase gas price by 20%
+            gasPrice = gasPrice * BigInt(120) / BigInt(100);
         }
 
         return {

--- a/services/blockchain-service/blockchain-service-base.js
+++ b/services/blockchain-service/blockchain-service-base.js
@@ -55,7 +55,7 @@ class BlockchainServiceBase {
         try {
             return await web3Instance.eth.getGasPrice();
         } catch (error) {
-            console.error(`Failed to fetch the gas price from the network: ${error}. Using default value: 100 Gwei.`);
+            console.warn(`Failed to fetch the gas price from the network: ${error}. Using default value: 100 Gwei.`);
             return Web3.utils.toWei('100', 'Gwei');
         }
     }

--- a/services/blockchain-service/implementations/node-blockchain-service.js
+++ b/services/blockchain-service/implementations/node-blockchain-service.js
@@ -54,7 +54,7 @@ class NodeBlockchainService extends BlockchainServiceBase {
     async executeContractFunction(contractName, functionName, args, blockchain) {
         const web3Instance = await this.getWeb3Instance(blockchain);
         let result;
-        let gasPrice;
+        let previousTxGasPrice;
         let transactionRetried = false;
 
         while (result === undefined) {
@@ -68,7 +68,7 @@ class NodeBlockchainService extends BlockchainServiceBase {
                     args,
                     blockchain,
                 );
-                gasPrice = tx.gasPrice;
+                previousTxGasPrice = tx.gasPrice;
                 // eslint-disable-next-line no-await-in-loop
                 const createdTransaction = await web3Instance.eth.accounts.signTransaction(
                     tx,
@@ -92,7 +92,7 @@ class NodeBlockchainService extends BlockchainServiceBase {
                     // eslint-disable-next-line no-param-reassign
                     blockchain.retryTx = true;
                     // eslint-disable-next-line no-param-reassign
-                    blockchain.gasPrice = gasPrice;
+                    blockchain.previousTxGasPrice = previousTxGasPrice;
                 } else {
                     throw e;
                 }


### PR DESCRIPTION
<img width="696" alt="image" src="https://github.com/OriginTrail/dkg.js/assets/71610423/3b7d02e9-6f0e-45e1-b12f-fa3f7b1c4fbe">
<img width="642" alt="image" src="https://github.com/OriginTrail/dkg.js/assets/71610423/e35cfe6a-e12b-422d-b5d8-73840df08283">

`blockchain.gasPrice` is supposed to be the value that user can set. On retry, we were setting it to the value of the gasPrice used for the first transaction. As a result, in the `prepareTransaction()` function, `blockchain.gasPrice` was never `undefined` on the retry and this condition was not executed:
<img width="401" alt="image" src="https://github.com/OriginTrail/dkg.js/assets/71610423/e569d281-f423-46f6-9874-b11f80901fff">
leaving `gasPrice` undefined.

With undefined `gasPrice`, this condition
<img width="494" alt="image" src="https://github.com/OriginTrail/dkg.js/assets/71610423/cf9e6350-d52f-444b-8ebe-b03a72c824c5">
was always `false`, because `undefined <= blockchain.gasPrice` is always `false`.

So, actual `gasPrice` increase was never executed on retry:
<img width="519" alt="image" src="https://github.com/OriginTrail/dkg.js/assets/71610423/518adfd8-afa5-418a-915f-cc8c35313049">

Also, at least 10% increase in gas price should happen for tx to be replaced, so I added **20%** increase instead of 1 Wei