### PR TITLE
[V6] Fix api versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dkg.js",
-    "version": "6.5.4",
+    "version": "6.5.5",
     "description": "Javascript library for interaction with the OriginTrail Decentralized Knowledge Graph",
     "main": "index.js",
     "scripts": {

--- a/services/node-api-service/implementations/http-service.js
+++ b/services/node-api-service/implementations/http-service.js
@@ -7,16 +7,14 @@ class HttpService {
         this.config = config;
 
         if (
-            !(
-                config.nodeApiVersion === '/' ||
-                config.nodeApiVersion === '/latest' ||
-                /^\/v\d+$/.test(config.nodeApiVersion)
-            )
+            config.nodeApiVersion === '/' ||
+            config.nodeApiVersion === '/latest' ||
+            /^\/v\d+$/.test(config.nodeApiVersion)
         ) {
-            throw Error(`Version must be '/latest', '/' or in '/v{digits}' format.`);
+            this.apiVersion = config.nodeApiVersion;
+        } else {
+            this.apiVersion = '/v0';
         }
-
-        this.apiVersion = config.nodeApiVersion ?? '/v0';
     }
 
     async info(endpoint, port, authToken) {


### PR DESCRIPTION
Currently it's erroring if you do not pass the version, since error happens before ?? 'v0' part. We need this update to make it backwards compatible