### PR TITLE
Remove unneccessary npx from scripts (sometimes breaks npm install)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "type": "module",
     "scripts": {
         "compile-contracts": "cd ./node_modules/dkg-evm-module && npm run compile",
-        "build": "npm run cjs-compat && npx webpack --config webpack.config.cjs",
-        "watch": "npm run cjs-compat && npx webpack --config webpack.config.cjs --watch --progress",
+        "build": "npm run cjs-compat && webpack --config webpack.config.cjs",
+        "watch": "npm run cjs-compat && webpack --config webpack.config.cjs --watch --progress",
         "lint": "eslint .",
-        "cjs-compat": "npx rollup index.js --file index.cjs --format cjs",
+        "cjs-compat": "rollup index.js --file index.cjs --format cjs",
         "postinstall": "npm run cjs-compat"
     },
     "repository": {


### PR DESCRIPTION
`npx` is not needed before a command when used inside of package.json scripts 
(This was my mistake when I was fixing cjs issues)