### PR TITLE
Sort the public triples before calculating the Merlke root, to match …

### DIFF
--- a/managers/asset-operations-manager.js
+++ b/managers/asset-operations-manager.js
@@ -329,11 +329,11 @@ export default class AssetOperationsManager {
                 publicTriplesGrouped.push([triple]);
             }
 
-            dataset.public = publicTriplesGrouped.flat();
+            dataset.public = publicTriplesGrouped.map((t) => t.sort()).flat();
         } else {
             // No private triples, just group and flatten public
             publicTriplesGrouped = kcTools.groupNquadsBySubject(dataset.public, true);
-            dataset.public = publicTriplesGrouped.flat();
+            dataset.public = publicTriplesGrouped.map((t) => t.sort()).flat();
         }
 
         const numberOfChunks = kcTools.calculateNumberOfChunks(dataset.public, CHUNK_BYTE_SIZE);


### PR DESCRIPTION
…the sort done in the dkg-engine validator

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sorts public triples within each subject group before flattening to ensure deterministic Merkle root computation.
> 
> - **Asset creation (`managers/asset-operations-manager.js`)**:
>   - In `create()`, when preparing `dataset.public`, sort triples within each subject group (`groupNquadsBySubject(...).map(t => t.sort()).flat()`) for both public-only and public+private flows.
>   - Ensures deterministic ordering of public triples prior to chunking and Merkle root calculation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df63cfc3d8d6806bf398e3bee0bcb4275670bd4b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->