### PR TITLE
percentile 80, bufferPercent multiply

### DIFF
--- a/services/blockchain-service/blockchain-service-base.js
+++ b/services/blockchain-service/blockchain-service-base.js
@@ -1451,6 +1451,7 @@ export default class BlockchainServiceBase {
         // Fallback to network gas price if feeHistory not supported or empty
         if (!feeHistory.supported) {
             return this.applyGasPriceBuffer(
+                0n, 
                 BigInt(await this.getNetworkGasPrice(blockchain)),
                 gasPriceBufferPercent,
             );
@@ -1461,6 +1462,7 @@ export default class BlockchainServiceBase {
 
         if (baseFees.length === 0 || priorityFees.length === 0) {
             return this.applyGasPriceBuffer(
+                0n, 
                 BigInt(await this.getNetworkGasPrice(blockchain)),
                 gasPriceBufferPercent,
             );

--- a/services/blockchain-service/blockchain-service-base.js
+++ b/services/blockchain-service/blockchain-service-base.js
@@ -1402,8 +1402,9 @@ export default class BlockchainServiceBase {
         try {
             // eth_feeHistory params: blockCount, newestBlock, rewardPercentiles
             // [50] = median priority fee per block
-            const feeHistory = await web3Instance.eth.getFeeHistory(blockCount, 'latest', [80]);
-            
+            const priorityFeePercentile = blockchain.priorityFeePercentile ?? 50;
+            const feeHistory = await web3Instance.eth.getFeeHistory(blockCount, 'latest', [priorityFeePercentile]);
+
             // Extract median priority fees from each block (reward[blockIndex][percentileIndex])
             const priorityFees = feeHistory.reward
                 ? feeHistory.reward.map((blockRewards) => BigInt(blockRewards[0] || 0))

--- a/services/blockchain-service/blockchain-service-base.js
+++ b/services/blockchain-service/blockchain-service-base.js
@@ -1402,8 +1402,8 @@ export default class BlockchainServiceBase {
         try {
             // eth_feeHistory params: blockCount, newestBlock, rewardPercentiles
             // [50] = median priority fee per block
-            const feeHistory = await web3Instance.eth.getFeeHistory(blockCount, 'latest', [50]);
-
+            const feeHistory = await web3Instance.eth.getFeeHistory(blockCount, 'latest', [80]);
+            
             // Extract median priority fees from each block (reward[blockIndex][percentileIndex])
             const priorityFees = feeHistory.reward
                 ? feeHistory.reward.map((blockRewards) => BigInt(blockRewards[0] || 0))
@@ -1426,13 +1426,14 @@ export default class BlockchainServiceBase {
 
     /**
      * Apply buffer percentage to a gas price
-     * @param {BigInt} gasPrice - Gas price in wei
+     * @param {BigInt} maxBaseFee - base fee in wei
+     * @param {BigInt} maxPriorityFee - priority fee in wei
      * @param {number} gasPriceBufferPercent - Buffer percentage to add
      * @returns {BigInt} Gas price with buffer applied
      */
-    applyGasPriceBuffer(gasPrice, gasPriceBufferPercent) {
-        if (!gasPriceBufferPercent) return gasPrice;
-        return (gasPrice * BigInt(100 + Number(gasPriceBufferPercent))) / 100n;
+    applyGasPriceBuffer(maxBaseFee, maxPriorityFee, gasPriceBufferPercent) {
+        if (!gasPriceBufferPercent) return maxBaseFee + maxPriorityFee;
+        return ((maxBaseFee * BigInt(100 + Number(gasPriceBufferPercent))) / 100n) + maxPriorityFee;
     }
 
     /**
@@ -1468,7 +1469,7 @@ export default class BlockchainServiceBase {
         const maxBaseFee = baseFees.reduce((max, bf) => (bf > max ? bf : max), 0n);
         const maxPriorityFee = priorityFees.reduce((max, pf) => (pf > max ? pf : max), 0n);
 
-        return this.applyGasPriceBuffer(maxBaseFee + maxPriorityFee, gasPriceBufferPercent);
+        return this.applyGasPriceBuffer(maxBaseFee, maxPriorityFee, gasPriceBufferPercent);
     }
 
     /**

--- a/services/blockchain-service/blockchain-service-base.js
+++ b/services/blockchain-service/blockchain-service-base.js
@@ -1402,7 +1402,7 @@ export default class BlockchainServiceBase {
         try {
             // eth_feeHistory params: blockCount, newestBlock, rewardPercentiles
             // [50] = median priority fee per block
-            const priorityFeePercentile = blockchain.priorityFeePercentile ?? 50;
+            const priorityFeePercentile = blockchain.priorityFeePercentile ?? 80;
             const feeHistory = await web3Instance.eth.getFeeHistory(blockCount, 'latest', [priorityFeePercentile]);
 
             // Extract median priority fees from each block (reward[blockIndex][percentileIndex])

--- a/services/input-service.js
+++ b/services/input-service.js
@@ -198,6 +198,10 @@ export default class InputService {
             options.blockchain?.gasPriceBufferPercent ??
             this.config.blockchain?.gasPriceBufferPercent ??
             undefined;
+        const priorityFeePercentile =
+            options.blockchain?.priorityFeePercentile ??
+            this.config.blockchain?.priorityFeePercentile ??
+            undefined;
         const retryTxGasPriceMultiplier =
             options.blockchain?.retryTxGasPriceMultiplier ??
             this.config.blockchain?.retryTxGasPriceMultiplier ??
@@ -218,6 +222,7 @@ export default class InputService {
             gasPriceOracleLink,
             maxAllowance,
             gasPriceBufferPercent,
+            priorityFeePercentile,
             retryTxGasPriceMultiplier,
         };
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Use a configurable priority fee percentile (default 80) for fee history and apply gas buffer to base fee only, with config plumbed via InputService.
> 
> - **Blockchain service (`services/blockchain-service/blockchain-service-base.js`)**:
>   - **Fee history**: Use configurable `blockchain.priorityFeePercentile` (default `80`) in `eth_getFeeHistory` instead of fixed `50`.
>   - **Gas price buffering**:
>     - Change `applyGasPriceBuffer(maxBaseFee, maxPriorityFee, gasPriceBufferPercent)` to apply buffer only to base fee and then add priority fee.
>     - Update `estimateGasPriceFromFeeHistory` to use new signature and handle fallbacks by separating base and priority components.
> - **Input service (`services/input-service.js`)**:
>   - Add and propagate `priorityFeePercentile` in `getBlockchain` config.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e6a648f8fdf107d5a567fa9a33fb5ea027e86b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->