### PR TITLE
update package-lock test

### DIFF
--- a/.github/workflows/check-package-lock.yml
+++ b/.github/workflows/check-package-lock.yml
@@ -10,10 +10,16 @@ concurrency:
 on:
   push:
     branches:
-      - main # Run on push to main branch only
+      - main
+    paths:
+      - "package.json"
+      - "package-lock.json"
   pull_request:
     branches:
-      - "**" # Run on PR to any branch
+      - "**"
+    paths:
+      - "package.json"
+      - "package-lock.json"
 
 jobs:
   verify-package-lock:
@@ -43,6 +49,26 @@ jobs:
             exit 1
           fi
           echo "SUCCESS: package-lock.json file is valid and not empty"
+
+      - name: Check package-lock.json is updated when package.json changes
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch origin ${{ github.base_ref }} --depth=1
+          
+          # Check if package.json was changed in this PR
+          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q "^package\.json$"; then
+            echo "package.json was modified - checking if package-lock.json was also updated..."
+            
+            if ! git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q "^package-lock\.json$"; then
+              echo "ERROR: package.json was changed but package-lock.json was NOT updated"
+              echo "Please run 'npm install' to update the lock file and commit it"
+              exit 1
+            fi
+            
+            echo "SUCCESS: Both package.json and package-lock.json were updated"
+          else
+            echo "SKIP: package.json was not modified, only package-lock.json changed"
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/check-package-lock.yml
+++ b/.github/workflows/check-package-lock.yml
@@ -50,26 +50,6 @@ jobs:
           fi
           echo "SUCCESS: package-lock.json file is valid and not empty"
 
-      - name: Check package-lock.json is updated when package.json changes
-        if: github.event_name == 'pull_request'
-        run: |
-          git fetch origin ${{ github.base_ref }} --depth=1
-          
-          # Check if package.json was changed in this PR
-          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q "^package\.json$"; then
-            echo "package.json was modified - checking if package-lock.json was also updated..."
-            
-            if ! git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q "^package-lock\.json$"; then
-              echo "ERROR: package.json was changed but package-lock.json was NOT updated"
-              echo "Please run 'npm install' to update the lock file and commit it"
-              exit 1
-            fi
-            
-            echo "SUCCESS: Both package.json and package-lock.json were updated"
-          else
-            echo "SKIP: package.json was not modified, only package-lock.json changed"
-          fi
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -77,3 +57,19 @@ jobs:
 
       - name: Validate package-lock.json is valid and in sync
         run: npm ci --dry-run --ignore-scripts
+
+      - name: Check package-lock.json is up to date with package.json
+        if: github.event_name == 'pull_request'
+        run: |
+          # Regenerate the lock file from the current package.json without
+          # installing node_modules, then check if it differs from what was committed.
+          cp package-lock.json package-lock.json.bak
+          npm install --package-lock-only --ignore-scripts
+          
+          if ! diff -q package-lock.json package-lock.json.bak > /dev/null 2>&1; then
+            echo "ERROR: package-lock.json is out of date with package.json"
+            echo "Please run 'npm install' and commit the updated package-lock.json"
+            exit 1
+          fi
+          
+          echo "SUCCESS: package-lock.json is up to date"

--- a/.github/workflows/check-package-lock.yml
+++ b/.github/workflows/check-package-lock.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
+          node-version: '20.x'
 
       - name: Validate package-lock.json is valid and in sync
         run: npm ci --dry-run --ignore-scripts


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only changes limited to workflow triggers and npm lockfile validation; main risk is false failures due to Node/npm version differences or lockfile regeneration behavior.
> 
> **Overview**
> The `check-package-lock` GitHub Actions workflow now only runs when `package.json` or `package-lock.json` change (on `main` pushes and all PRs), reducing unnecessary CI runs.
> 
> It upgrades the job to Node `20.x` and adds a PR-only step that regenerates `package-lock.json` (`npm install --package-lock-only`) and fails the build if the committed lockfile is out of date relative to `package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4030151a985c027808e854674867fd39e2d3af1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->