### PR TITLE
Fix for approve called without sufficient trac

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "dkg.js",
-    "version": "8.2.3",
+    "version": "8.2.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "dkg.js",
-            "version": "8.2.3",
+            "version": "8.2.4",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dkg.js",
-    "version": "8.2.3",
+    "version": "8.2.4",
     "description": "Javascript library for interaction with the OriginTrail Decentralized Knowledge Graph",
     "main": "index.js",
     "exports": {

--- a/services/blockchain-service/blockchain-service-base.js
+++ b/services/blockchain-service/blockchain-service-base.js
@@ -510,6 +510,25 @@ export default class BlockchainServiceBase {
             if (requestData?.paymaster && requestData?.paymaster !== ZERO_ADDRESS) {
                 // Handle the case when payer is passed
             } else {
+                const senderBalance = await this.callContractFunction(
+                    'Token',
+                    'balanceOf',
+                    [sender],
+                    blockchain,
+                );
+
+                if (BigInt(senderBalance) < BigInt(requestData.tokenAmount)) {
+                    const balance = Number(senderBalance) / 1e18;
+                    const required = Number(requestData.tokenAmount) / 1e18;
+
+                    throw new Error(
+                        `Insufficient TRAC token balance to publish. ` +
+                            `Wallet ${sender} has ${balance} TRAC, ` +
+                            `but the publish operation requires ${required} TRAC. ` +
+                            `Please fund your wallet with more TRAC tokens to proceed.`,
+                    );
+                }
+
                 await this.increaseKnowledgeCollectionAllowance(
                     sender,
                     requestData.tokenAmount,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new on-chain balance check and throws earlier during publishing; low complexity but touches token-spend gating and introduces a human-readable conversion that could mislead if token decimals differ.
> 
> **Overview**
> Bumps the library version to `8.2.4`.
> 
> When creating a knowledge collection, the flow now checks the sender’s TRAC `balanceOf` before attempting to `approve`/increase allowance (when no paymaster is used). If the wallet balance is below `requestData.tokenAmount`, it fails fast with a clearer “insufficient TRAC” error message instead of proceeding to an approval call.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c4f43782f1f4453647e76638d88c269b4644e3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->